### PR TITLE
Satisfy deprecation warning

### DIFF
--- a/lib/rspec/rake.rb
+++ b/lib/rspec/rake.rb
@@ -3,8 +3,6 @@ require 'rspec/rake/example_group'
 
 RSpec.configure do |config|
   config.include RSpec::Rake::ExampleGroup,
-    :type => :task,
-    :example_group => lambda { |example_group, metadata|
-      metadata[:type].nil? && %r{spec/tasks}.match(example_group[:file_path])
-    }
+    type: :task,
+    file_path: /\bspec\/tasks\//
 end


### PR DESCRIPTION
This resolves the following deprecation warning under Rails 4.2.6 and rspec 3.4.4:

```
Deprecation Warnings:

Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead. Called from /Users/lyndsy.simon/src/gems/rspec-rake/lib/rspec/rake.rb:5:in `block in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```