### PR TITLE
Ensure rspec is loaded before configuring the gem

### DIFF
--- a/lib/rspec/rake.rb
+++ b/lib/rspec/rake.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'rspec/rake/version'
 require 'rspec/rake/example_group'
 


### PR DESCRIPTION
Without this require statement, rspec is not loaded before rspec-rake. Here's an excerpt illustrating this failure:

```bash
$ export RAILS_ENV="test"
$ export RACK_ENV="test"
$ bundle exec rake db:create db:schema:load --trace
rake aborted!
NoMethodError: undefined method `configure' for RSpec:Module
/home/ubuntu/cobalt2/vendor/bundle/ruby/2.3.0/gems/rspec-rake-0.0.3/lib/rspec/rake.rb:4:in `<top (required)>'
```
